### PR TITLE
Resolve Migration "change" methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,12 @@ gem "puma"
 
 gem "sqlite3"
 
-gem "propshaft"
+# This needs to match the version in pin_flags.gemspec
+gem "propshaft", "~> 1.0"
 
+# This needs to match the version in pin_flags.gemspec
 # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-gem "rubocop-rails-omakase", require: false
+gem "rubocop-rails-omakase", "~> 1.0", require: false
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    pin_flags (0.1.0)
-      rails (>= 8.0.2)
-      turbo-rails
+    pin_flags (0.1.1)
+      rails (~> 8.0, >= 8.0.2)
+      turbo-rails (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -223,9 +223,9 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sqlite3 (2.7.2-x86_64-linux-gnu)
+    sqlite3 (2.7.3-x86_64-linux-gnu)
     stringio (3.1.7)
-    thor (1.3.2)
+    thor (1.4.0)
     timeout (0.4.3)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
@@ -247,12 +247,12 @@ PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
-  debug
+  debug (~> 1.9)
   pin_flags!
-  propshaft
+  propshaft (~> 1.0)
   puma
-  rubocop-performance
-  rubocop-rails-omakase
+  rubocop-performance (~> 1.21)
+  rubocop-rails-omakase (~> 1.0)
   sqlite3
 
 BUNDLED WITH

--- a/lib/generators/pin_flags/install/templates/create_feature_subscriptions.rb
+++ b/lib/generators/pin_flags/install/templates/create_feature_subscriptions.rb
@@ -1,14 +1,22 @@
 class CreateFeatureSubscriptions < ActiveRecord::Migration[8.0]
-  def change
+  def up
     create_table :pin_flags_feature_subscriptions do |t|
       t.references :feature_tag, null: false, foreign_key: { to_table: :pin_flags_feature_tags }
-      t.references :feature_taggable, polymorphic: true, null: false
+      t.references :feature_taggable, polymorphic: true, null: false, index: false
 
       t.timestamps
     end
 
-    add_index :pin_flags_feature_subscriptions, [ :feature_taggable_type, :feature_taggable_id ]
-    add_index :pin_flags_feature_subscriptions, [ :feature_tag_id, :feature_taggable_type, :feature_taggable_id ],
-              unique: true, name: "index_feature_subscriptions_unique"
+    add_index :pin_flags_feature_subscriptions,
+              %i[feature_tag_id feature_taggable_type feature_taggable_id],
+              unique: true,
+              name: "idx_pf_subs_on_tag_and_taggable"
+  end
+
+  def down
+    if table_exists?(:pin_flags_feature_subscriptions)
+      remove_index :pin_flags_feature_subscriptions, name: "idx_pf_subs_on_tag_and_taggable" if index_exists?(:pin_flags_feature_subscriptions, name: "idx_pf_subs_on_tag_and_taggable")
+      drop_table :pin_flags_feature_subscriptions
+    end
   end
 end

--- a/lib/generators/pin_flags/install/templates/create_feature_tag.rb
+++ b/lib/generators/pin_flags/install/templates/create_feature_tag.rb
@@ -1,5 +1,5 @@
 class CreateFeatureTag < ActiveRecord::Migration[8.0]
-  def change
+  def up
     create_table :pin_flags_feature_tags do |t|
       t.string :name, null: false
       t.boolean :enabled, default: true, null: false
@@ -8,5 +8,12 @@ class CreateFeatureTag < ActiveRecord::Migration[8.0]
     end
 
     add_index :pin_flags_feature_tags, :name, unique: true
+  end
+
+  def down
+    if table_exists?(:pin_flags_feature_tags)
+      remove_index :pin_flags_feature_tags, :name if index_exists?(:pin_flags_feature_tags, :name)
+      drop_table :pin_flags_feature_tags
+    end
   end
 end

--- a/lib/pin_flags/version.rb
+++ b/lib/pin_flags/version.rb
@@ -1,3 +1,3 @@
 module PinFlags
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This pull request introduces several changes to improve compatibility, enhance database migration handling, and update versioning. The most significant updates include specifying gem versions in the `Gemfile`, refactoring migrations to include `up` and `down` methods for better rollback support, and incrementing the library version.

### Dependency Updates:
* Updated `Gemfile` to specify version constraints for `propshaft` and `rubocop-rails-omakase` gems, ensuring compatibility with the `pin_flags.gemspec` file.

### Database Migration Enhancements:
* Refactored `create_feature_subscriptions.rb` migration to replace the `change` method with `up` and `down` methods. This includes adding a unique index with a new name (`idx_pf_subs_on_tag_and_taggable`) and ensuring proper rollback functionality.
* Refactored `create_feature_tag.rb` migration to replace the `change` method with `up` and `down` methods, adding rollback support for the `pin_flags_feature_tags` table and its unique index on the `name` column. [[1]](diffhunk://#diff-c0210e335b47840f5f90d00de319f35baa9a395e7d2d4a35a1a4a57eb0cc05dbL2-R2) [[2]](diffhunk://#diff-c0210e335b47840f5f90d00de319f35baa9a395e7d2d4a35a1a4a57eb0cc05dbR12-R18)

### Version Update:
* Incremented the library version in `lib/pin_flags/version.rb` from `0.1.0` to `0.1.1`, reflecting the new changes.