### PR TITLE
Add http_basic_auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,48 @@ PinFlags.config do |config|
 end
 ```
 
+### HTTP Basic Authentication
+
+PinFlags includes built-in HTTP Basic Authentication to protect the admin interface. Configure it in your initializer:
+
+```ruby
+PinFlags.config do |config|
+  config.cache_prefix = "budget_tracker_pin_flags"
+  config.cache_expiry = 1.hour
+  config.http_basic_auth_enabled = true    # Default: true
+  config.http_basic_auth_user = "admin"    # Default: "pin_flags_admin"  
+  config.http_basic_auth_password = "password"  # Default: "please_change_me"
+end
+```
+
+**Security Note:** Always change the default credentials in production environments.
+
+### Consider using environment variables for sensitive information:
+
+```ruby
+PinFlags.config do |config|
+  config.http_basic_auth_user = ENV["PIN_FLAGS_USER"] || "pin_flags_admin"
+  config.http_basic_auth_password = ENV["PIN_FLAGS_PASSWORD"] || "please_change_me"
+end
+```
+
+### Or use Rails credentials:
+
+```ruby
+PinFlags.config do |config|
+  config.http_basic_auth_user = Rails.application.credentials.pin_flags[:user] || "pin_flags_admin"
+  config.http_basic_auth_password = Rails.application.credentials.pin_flags[:password] || "please_change_me"
+end
+```
+
+To disable authentication entirely:
+
+```ruby
+PinFlags.config do |config|
+  config.http_basic_auth_enabled = false
+end
+```
+
 ## Usage
 
 ### Include the module in any of your ActiveRecord models:
@@ -167,6 +209,9 @@ end
 |--------|-------------|---------|
 | `cache_prefix` | Prefix for cache keys | `"pin_flags"` |
 | `cache_expiry` | Cache expiration time | `12.hours` |
+| `http_basic_auth_enabled` | Enable HTTP Basic Authentication | `true` |
+| `http_basic_auth_user` | Username for admin interface | `"pin_flags_admin"` |
+| `http_basic_auth_password` | Password for admin interface | `"secure_password"` |
 
 ## Development
 

--- a/app/controllers/concerns/pin_flags/basic_authentication.rb
+++ b/app/controllers/concerns/pin_flags/basic_authentication.rb
@@ -1,0 +1,25 @@
+module PinFlags::BasicAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_by_http_basic
+  end
+
+  private
+    def authenticate_by_http_basic
+      if http_basic_authentication_enabled?
+        http_basic_authenticate_or_request_with(**http_basic_authentication_credentials)
+      end
+    end
+
+    def http_basic_authentication_enabled?
+      PinFlags.http_basic_auth_enabled
+    end
+
+    def http_basic_authentication_credentials
+      {
+        name: PinFlags.http_basic_auth_user,
+        password: PinFlags.http_basic_auth_password
+      }.transform_values(&:presence)
+    end
+end

--- a/app/controllers/pin_flags/application_controller.rb
+++ b/app/controllers/pin_flags/application_controller.rb
@@ -1,5 +1,7 @@
 module PinFlags
   class ApplicationController < ActionController::Base
+    include PinFlags::BasicAuthentication
+
     layout "pin_flags/application"
     protect_from_forgery with: :exception
   end

--- a/lib/pin_flags.rb
+++ b/lib/pin_flags.rb
@@ -6,6 +6,10 @@ module PinFlags
   mattr_accessor :cache_prefix, default: "pin_flags"
   mattr_accessor :cache_expiry, default: 12.hours
 
+  mattr_accessor :http_basic_auth_enabled, default: true
+  mattr_accessor :http_basic_auth_user, default: "pin_flags_admin"
+  mattr_accessor :http_basic_auth_password, default: "please_change_me"
+
   def self.config
     yield self if block_given?
     self


### PR DESCRIPTION
This pull request introduces HTTP Basic Authentication to the `PinFlags` admin interface, enhancing security and configurability. The changes include new configuration options, a reusable authentication module, and updates to the documentation.

### Authentication Feature Implementation:

* **New authentication module**: Added `PinFlags::BasicAuthentication` concern to handle HTTP Basic Authentication, including methods to enable/disable authentication and configure credentials (`app/controllers/concerns/pin_flags/basic_authentication.rb`).
* **Controller integration**: Integrated the `PinFlags::BasicAuthentication` module into `PinFlags::ApplicationController` to enforce authentication for admin routes (`app/controllers/pin_flags/application_controller.rb`).

### Configuration Enhancements:

* **New configuration options**: Added `http_basic_auth_enabled`, `http_basic_auth_user`, and `http_basic_auth_password` as configurable attributes in `PinFlags` (`lib/pin_flags.rb`).

### Documentation Updates:

* **Authentication setup guide**: Updated the `README.md` with detailed instructions on enabling and configuring HTTP Basic Authentication, including examples for using environment variables and Rails credentials (`README.md`).
* **Configuration table**: Added the new authentication-related configuration options to the configuration table in the documentation (`README.md`).